### PR TITLE
feat(core,suite,server): Add MessageQueue

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -50,6 +50,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.0.0",
     "@nestjs/typeorm": "^11.0.0",
     "@supabase/supabase-js": "^2.49.4",
     "axios": "^1.9.0",

--- a/apps/server/src/modules/app.module.ts
+++ b/apps/server/src/modules/app.module.ts
@@ -1,5 +1,6 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
 
 import { ProxyMiddleware } from '../middleware/x402-redirect.middleware';
 import { ChatModule } from './chat/chat.module';
@@ -7,11 +8,14 @@ import { DatabaseModule } from './databases/database.module';
 import { GrowlyModule } from './growly/growly.module';
 import { MessageModule } from './message/message.module';
 import { OpenAIModule } from './openai/openai.module';
+import { PersonaModule } from './persona/persona.module';
 import { SuiteCoreModule } from './suite-core/suite-core.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true }),
+    ScheduleModule.forRoot(),
+    PersonaModule,
     DatabaseModule,
     OpenAIModule,
     ChatModule,

--- a/apps/server/src/modules/persona/persona.module.ts
+++ b/apps/server/src/modules/persona/persona.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+
+import { DatabaseModule } from '../databases/database.module';
+import { QueueModule } from '../queue/queue.module';
+import { PersonaService } from './persona.service';
+
+@Module({
+  imports: [DatabaseModule, QueueModule],
+  providers: [PersonaService],
+  exports: [],
+})
+export class PersonaModule {}

--- a/apps/server/src/modules/persona/persona.service.ts
+++ b/apps/server/src/modules/persona/persona.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+
+import { QueueService } from '../queue/queue.service';
+
+@Injectable()
+export class PersonaService implements OnModuleInit {
+  private readonly logger = new Logger(PersonaService.name);
+
+  constructor(private readonly queueService: QueueService) {}
+
+  onModuleInit() {
+    // Initialize the queue service with the persona queue name
+    this.queueService.initialize('persona');
+  }
+
+  @Interval(10000)
+  async checkPersonaQueue() {
+    this.logger.debug('Checking persona queue for new requests');
+
+    // Check if there are messages to process
+    const hasMessages = await this.queueService.hasMessages();
+
+    if (hasMessages) {
+      // Process all available messages
+      const result = await this.queueService.processAllMessages(message =>
+        this.processPersonaRequest(message)
+      );
+
+      this.logger.log(
+        `Persona queue processing completed. Processed: ${result.processed}, Errors: ${result.errors}`
+      );
+    }
+  }
+
+  /**
+   * Process a single persona creation request
+   */
+  private async processPersonaRequest(message: any): Promise<void> {
+    const walletAddress = message.message.walletAddress;
+
+    if (!walletAddress) {
+      throw new Error('Message missing required walletAddress field');
+    }
+
+    this.logger.debug(`Processing persona creation request for wallet: ${walletAddress}`);
+
+    try {
+      await this.createPersona(walletAddress);
+      this.logger.log(`Successfully created persona for wallet: ${walletAddress}`);
+    } catch (error) {
+      this.logger.error(`Failed to create persona for wallet ${walletAddress}:`, error);
+      throw error; // Re-throw to be counted as an error in queue processing
+    }
+  }
+
+  /**
+   * Create a persona for the given wallet address
+   * This is where the actual persona creation logic will go
+   */
+  private async createPersona(walletAddress: string): Promise<void> {
+    // TODO: Implement persona creation logic
+    this.logger.debug(`Creating persona for ${walletAddress}`);
+
+    // Placeholder for actual implementation
+    // Example steps:
+    // 1. Validate wallet address
+    // 2. Fetch user data
+    // 3. Generate persona attributes
+    // 4. Save to database
+    // 5. Send confirmation/notification
+
+    // Simulate async work
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}

--- a/apps/server/src/modules/queue/queue.module.ts
+++ b/apps/server/src/modules/queue/queue.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { DatabaseModule } from '../databases/database.module';
+import { QueueService } from './queue.service';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [QueueService],
+  exports: [QueueService],
+})
+export class QueueModule {}

--- a/apps/server/src/modules/queue/queue.service.ts
+++ b/apps/server/src/modules/queue/queue.service.ts
@@ -1,0 +1,214 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+
+import { SuiteDatabaseCore } from '@getgrowly/core';
+
+@Injectable()
+export class QueueService {
+  private readonly logger = new Logger(QueueService.name);
+  private queueName: string;
+
+  constructor(@Inject('GROWLY_SUITE_CORE') private readonly suiteCore: SuiteDatabaseCore) {}
+
+  /**
+   * Initialize the queue service with a specific queue name
+   */
+  initialize(queueName: string): void {
+    this.queueName = queueName;
+    this.logger.debug(`QueueService initialized for queue: ${queueName}`);
+  }
+
+  /**
+   * Get the current queue name
+   */
+  getQueueName(): string {
+    return this.queueName;
+  }
+
+  /**
+   * Read messages from the queue without removing them
+   */
+  async readQueue(numMessages = 100, sleepSeconds = 0): Promise<any[]> {
+    if (!this.queueName) {
+      throw new Error('QueueService not initialized. Call initialize() with queue name first.');
+    }
+
+    try {
+      const result = await this.suiteCore.queue.getQueue(this.queueName, numMessages, sleepSeconds);
+      this.logger.debug(`Read ${result.length} messages from queue: ${this.queueName}`);
+      return result;
+    } catch (error) {
+      this.logger.error(`Error reading from queue ${this.queueName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Pop all messages from the queue
+   */
+  async popMessages(): Promise<any[]> {
+    if (!this.queueName) {
+      throw new Error('QueueService not initialized. Call initialize() with queue name first.');
+    }
+
+    try {
+      const result = await this.suiteCore.queue.popFromQueue(this.queueName);
+      if (result && result.length > 0) {
+        this.logger.debug(`Popped message from queue: ${this.queueName}`);
+        return result;
+      }
+      return [];
+    } catch (error) {
+      this.logger.error(`Error popping from queue ${this.queueName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Check if queue has messages available
+   */
+  async hasMessages(): Promise<boolean> {
+    try {
+      const messages = await this.readQueue(1, 0);
+      return messages.length > 0;
+    } catch (error) {
+      this.logger.error(`Error checking messages in queue ${this.queueName}:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Pop and process all available messages with a callback function
+   * Only deletes messages after successful processing
+   */
+  async processAllMessages<T>(
+    processor: (message: any) => Promise<T>
+  ): Promise<{ processed: number; errors: number }> {
+    let processedCount = 0;
+    let errorCount = 0;
+
+    this.logger.debug(`Starting to process all messages from queue: ${this.queueName}`);
+
+    try {
+      // Read all available messages without visibility timeout to avoid delays
+      const messages = await this.readQueue(); // Read up to 100 messages, no sleep
+
+      if (messages.length > 0) {
+        this.logger.debug(
+          `Found ${messages.length} messages to process in queue: ${this.queueName}`
+        );
+
+        // Process each message
+        for (const message of messages) {
+          try {
+            // Process the message
+            await processor(message);
+
+            // Only delete the message if processing succeeded
+            // await this.deleteMessage(message.msg_id);
+            processedCount++;
+
+            this.logger.debug(
+              `Successfully processed and deleted message ${message.msg_id} from queue: ${this.queueName}`
+            );
+          } catch (processingError) {
+            this.logger.error(
+              `Error processing message ${message.msg_id} from queue ${this.queueName}. Message will remain in queue:`,
+              processingError
+            );
+            errorCount++;
+            // Continue processing other messages instead of stopping
+          }
+        }
+      } else {
+        this.logger.debug(`No messages found in queue: ${this.queueName}`);
+      }
+    } catch (readError) {
+      this.logger.error(`Error reading from queue ${this.queueName}:`, readError);
+      errorCount++;
+    }
+
+    this.logger.debug(
+      `Finished processing queue ${this.queueName}. Processed: ${processedCount}, Errors: ${errorCount}`
+    );
+    return { processed: processedCount, errors: errorCount };
+  }
+
+  /**
+   * Send a single message to the queue
+   */
+  async sendMessage(message: any, sleepSeconds = 0): Promise<any> {
+    if (!this.queueName) {
+      throw new Error('QueueService not initialized. Call initialize() with queue name first.');
+    }
+
+    try {
+      const result = await this.suiteCore.queue.addToQueue(this.queueName, message, sleepSeconds);
+      this.logger.debug(
+        `Sent message to queue ${this.queueName}${sleepSeconds > 0 ? ` with ${sleepSeconds}s delay` : ''}`
+      );
+      return result;
+    } catch (error) {
+      this.logger.error(`Error sending message to queue ${this.queueName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Send multiple messages to the queue in batch
+   */
+  async sendBatchMessages(messages: any[], sleepSeconds = 0): Promise<any> {
+    if (!this.queueName) {
+      throw new Error('QueueService not initialized. Call initialize() with queue name first.');
+    }
+
+    try {
+      const result = await this.suiteCore.queue.sendBatch(this.queueName, messages, sleepSeconds);
+      this.logger.debug(
+        `Sent ${messages.length} messages to queue ${this.queueName}${sleepSeconds > 0 ? ` with ${sleepSeconds}s delay` : ''}`
+      );
+      return result;
+    } catch (error) {
+      this.logger.error(`Error sending batch messages to queue ${this.queueName}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Archive a message by moving it to the archive table
+   */
+  async archiveMessage(messageId: number): Promise<any> {
+    if (!this.queueName) {
+      throw new Error('QueueService not initialized. Call initialize() with queue name first.');
+    }
+
+    try {
+      const result = await this.suiteCore.queue.archiveMessage(this.queueName, messageId);
+      this.logger.debug(`Archived message ${messageId} from queue ${this.queueName}`);
+      return result;
+    } catch (error) {
+      this.logger.error(
+        `Error archiving message ${messageId} from queue ${this.queueName}:`,
+        error
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Permanently delete a message from the queue
+   */
+  async deleteMessage(messageId: number): Promise<any> {
+    if (!this.queueName) {
+      throw new Error('QueueService not initialized. Call initialize() with queue name first.');
+    }
+
+    try {
+      const result = await this.suiteCore.queue.deleteMessage(this.queueName, messageId);
+      this.logger.debug(`Deleted message ${messageId} from queue ${this.queueName}`);
+      return result;
+    } catch (error) {
+      this.logger.error(`Error deleting message ${messageId} from queue ${this.queueName}:`, error);
+      throw error;
+    }
+  }
+}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -6,6 +6,7 @@ import {
   FunctionService,
   OrganizationService,
   PublicDatabaseService,
+  QueueService,
   StepService,
   UserService,
   WorkflowService,
@@ -84,6 +85,9 @@ export interface SuiteDatabaseCore {
 
   /** Function services. */
   fn: FunctionService;
+
+  /** Queue services. */
+  queue: QueueService;
 }
 
 /**
@@ -139,6 +143,8 @@ export const createSuiteCore = (supabaseUrl: string, supabaseKey: string): Suite
   // Edge functions.
   const functionService = new FunctionService(supabaseClientService);
 
+  const queueService = new QueueService(supabaseClientService);
+
   // Custom services.
   const workflowService = new WorkflowService(
     workflowDatabaseService,
@@ -189,6 +195,7 @@ export const createSuiteCore = (supabaseUrl: string, supabaseKey: string): Suite
   return {
     db,
     fn: functionService,
+    queue: queueService,
     agents: agentService,
     conversations: conversationService,
     workflows: workflowService,

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -3,6 +3,7 @@ export * from './conversation.service';
 export * from './database.service';
 export * from './function.service';
 export * from './organization.service';
+export * from './queue.service';
 export * from './step.service';
 export * from './user.service';
 export * from './workflow-execution.service';

--- a/packages/core/src/services/queue.service.ts
+++ b/packages/core/src/services/queue.service.ts
@@ -1,0 +1,65 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * Interact with the queue in `pgmq_public` schema.
+ */
+export class QueueService {
+  constructor(private supabase: SupabaseClient) {}
+  SCHEMA = 'pgmq_public';
+
+  async addToQueue(queueName: string, message: any, sleepSeconds = 0) {
+    const result = await this.supabase.schema(this.SCHEMA).rpc('send', {
+      queue_name: queueName,
+      message,
+      sleep_seconds: sleepSeconds,
+    });
+    if (result.error) throw result.error;
+    return result.data;
+  }
+
+  async popFromQueue(queueName: string) {
+    const result = await this.supabase.schema(this.SCHEMA).rpc('pop', {
+      queue_name: queueName,
+    });
+    if (result.error) throw result.error;
+    return result.data;
+  }
+
+  async getQueue(queueName: string, numMessages = 100, sleepSeconds = 0) {
+    const result = await this.supabase.schema(this.SCHEMA).rpc('read', {
+      queue_name: queueName,
+      sleep_seconds: sleepSeconds,
+      n: numMessages,
+    });
+    if (result.error) throw result.error;
+    return result.data;
+  }
+
+  async sendBatch(queueName: string, messages: any[], sleepSeconds = 0) {
+    const result = await this.supabase.schema(this.SCHEMA).rpc('send_batch', {
+      queue_name: queueName,
+      messages,
+      sleep_seconds: sleepSeconds,
+    });
+    if (result.error) throw result.error;
+    return result.data;
+  }
+
+  async archiveMessage(queueName: string, messageId: number) {
+    const result = await this.supabase.schema(this.SCHEMA).rpc('archive', {
+      queue_name: queueName,
+      message_id: messageId,
+    });
+    if (result.error) throw result.error;
+    return result.data;
+  }
+
+  async deleteMessage(queueName: string, messageId: number) {
+    const result = await this.supabase.schema(this.SCHEMA).rpc('delete', {
+      queue_name: queueName,
+      message_id: messageId,
+    });
+    if (result.error) throw result.error;
+    return result.data;
+  }
+}

--- a/packages/suite/src/hooks/use-session.tsx
+++ b/packages/suite/src/hooks/use-session.tsx
@@ -111,6 +111,10 @@ export const useSuiteSession = create<WidgetSession>((set, get) => ({
       const user = await suiteCoreService.call('users', 'createUserFromAddressIfNotExist', [
         walletAddress,
       ]);
+
+      // Send to queue to create persona, no sleep
+      await suiteCoreService.call('queue', 'addToQueue', ['persona', { walletAddress }]);
+
       set({ user: user as ParsedUser });
       return user as ParsedUser;
     } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,6 +446,9 @@ importers:
       '@nestjs/platform-express':
         specifier: ^11.0.1
         version: 11.1.2(@nestjs/common@11.1.2(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.2)
+      '@nestjs/schedule':
+        specifier: ^6.0.0
+        version: 6.0.0(@nestjs/common@11.1.2(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.2)
       '@nestjs/typeorm':
         specifier: ^11.0.0
         version: 11.0.0(@nestjs/common@11.1.2(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.24(babel-plugin-macros@3.1.0)(pg@8.15.6)(reflect-metadata@0.2.2)(ts-node@10.9.2(@swc/core@1.11.24(@swc/helpers@0.5.17))(@types/node@22.15.23)(typescript@5.8.3)))
@@ -4253,6 +4256,12 @@ packages:
       '@nestjs/common': ^11.0.0
       '@nestjs/core': ^11.0.0
 
+  '@nestjs/schedule@6.0.0':
+    resolution: {integrity: sha512-aQySMw6tw2nhitELXd3EiRacQRgzUKD9mFcUZVOJ7jPLqIBvXOyvRWLsK9SdurGA+jjziAlMef7iB5ZEFFoQpw==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@nestjs/core': ^10.0.0 || ^11.0.0
+
   '@nestjs/schematics@11.0.5':
     resolution: {integrity: sha512-T50SCNyqCZ/fDssaOD7meBKLZ87ebRLaJqZTJPvJKjlib1VYhMOCwXYsr7bjMPmuPgiQHOwvppz77xN/m6GM7A==}
     peerDependencies:
@@ -7293,6 +7302,9 @@ packages:
   '@types/lru-cache@5.1.1':
     resolution: {integrity: sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==}
 
+  '@types/luxon@3.6.2':
+    resolution: {integrity: sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==}
+
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
@@ -9017,6 +9029,10 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cron@4.3.0:
+    resolution: {integrity: sha512-ciiYNLfSlF9MrDqnbMdRWFiA6oizSF7kA1osPP9lRzNu0Uu+AWog1UKy7SkckiDY2irrNjeO6qLyKnXC8oxmrw==}
+    engines: {node: '>=18.x'}
 
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
@@ -11651,6 +11667,10 @@ packages:
     resolution: {integrity: sha512-HGGkdlPWQ0vTF8jJ5TdIqhQXZi6uh3LnNgfZ8MHiuxFfX3RZeA79r2MW2tHAZKlAVfoNE8esm3p+O6VkIvpj6w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  luxon@3.6.1:
+    resolution: {integrity: sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==}
+    engines: {node: '>=12'}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -19764,6 +19784,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nestjs/schedule@6.0.0(@nestjs/common@11.1.2(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.2)':
+    dependencies:
+      '@nestjs/common': 11.1.2(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.2(@nestjs/common@11.1.2(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.2)(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      cron: 4.3.0
+
   '@nestjs/schematics@11.0.5(chokidar@4.0.3)(typescript@5.8.3)':
     dependencies:
       '@angular-devkit/core': 19.2.6(chokidar@4.0.3)
@@ -24072,6 +24098,8 @@ snapshots:
 
   '@types/lru-cache@5.1.1': {}
 
+  '@types/luxon@3.6.2': {}
+
   '@types/methods@1.1.4': {}
 
   '@types/mime@1.3.5': {}
@@ -27586,6 +27614,11 @@ snapshots:
 
   create-require@1.1.1: {}
 
+  cron@4.3.0:
+    dependencies:
+      '@types/luxon': 3.6.2
+      luxon: 3.6.1
+
   cross-fetch@3.2.0(encoding@0.1.13):
     dependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
@@ -30956,6 +30989,8 @@ snapshots:
   lucide-react@0.503.0(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  luxon@3.6.1: {}
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
**What changed? Why?**
- Add message queue to tech stack
- Suite will send payload to `persona` queue when there's a new user
- NestJS server will now check the queue every 10s with batch size 100, then build persona for each

**Notes to reviewers**
AS IS limitations:
- No type-enforcement for queue payload (the current `persona` queue is taking payload as `{walletAddress: 0x...}`
- Onboard MessageQueue service first -> currently mock behavior of persona builder

**How has it been tested?**
Normal scanning
![SCR-20250617-lfmt](https://github.com/user-attachments/assets/973634e5-6ac9-41e6-8557-fd090e5e5f13)

New message on queue send to Supabase
![image](https://github.com/user-attachments/assets/856d1924-bc64-49b5-9d19-0de3628f01e7)

When a new wallet comes in 
![image](https://github.com/user-attachments/assets/82d4c6a5-bd19-454f-894b-d73c1289c100)
