### PR TITLE
fix: agent-resource selection

### DIFF
--- a/packages/core/src/services/agent.service.ts
+++ b/packages/core/src/services/agent.service.ts
@@ -32,21 +32,18 @@ export class AgentService {
     // Update associations and track visited workflows.
     const visitedWorkflows: Record<string, boolean> = {};
     for (const workflow of agent.workflows) {
+      // Mark as visited before attempting DB ops to avoid accidental deletions on errors
+      visitedWorkflows[workflow.id] = true;
       try {
-        // Avoid duplicates by checking for existing association first
-        const existing = await this.agentWorkflowsDatabaseService.getOneByFields({
-          agent_id: updatedAgent.id,
-          workflow_id: workflow.id,
-        } as any);
-        if (!existing) {
-          await this.agentWorkflowsDatabaseService.create({
+        await this.agentWorkflowsDatabaseService.upsert(
+          {
             agent_id: updatedAgent.id,
             workflow_id: workflow.id,
             status: Status.Active,
-          });
-        }
-        visitedWorkflows[workflow.id] = true;
-      } catch (error) {
+          } as any,
+          ['agent_id', 'workflow_id']
+        );
+      } catch (error: any) {
         console.error('Failed to upsert agent-workflow association:', error);
       }
     }
@@ -54,21 +51,18 @@ export class AgentService {
     // Update resources and track visited resources.
     const visitedResources: Record<string, boolean> = {};
     for (const resource of agent.resources) {
+      // Mark as visited before attempting DB ops to avoid accidental deletions on errors
+      visitedResources[resource.id] = true;
       try {
-        // Avoid duplicates by checking for existing association first
-        const existing = await this.agentResourcesDatabaseService.getOneByFields({
-          agent_id: updatedAgent.id,
-          resource_id: resource.id,
-        } as any);
-        if (!existing) {
-          await this.agentResourcesDatabaseService.create({
+        await this.agentResourcesDatabaseService.upsert(
+          {
             agent_id: updatedAgent.id,
             resource_id: resource.id,
             status: Status.Active,
-          });
-        }
-        visitedResources[resource.id] = true;
-      } catch (error) {
+          } as any,
+          ['agent_id', 'resource_id']
+        );
+      } catch (error: any) {
         console.error('Failed to upsert agent-resource association:', error);
       }
     }

--- a/packages/core/src/services/agent.service.ts
+++ b/packages/core/src/services/agent.service.ts
@@ -33,14 +33,21 @@ export class AgentService {
     const visitedWorkflows: Record<string, boolean> = {};
     for (const workflow of agent.workflows) {
       try {
-        await this.agentWorkflowsDatabaseService.create({
+        // Avoid duplicates by checking for existing association first
+        const existing = await this.agentWorkflowsDatabaseService.getOneByFields({
           agent_id: updatedAgent.id,
           workflow_id: workflow.id,
-          status: Status.Active,
-        });
+        } as any);
+        if (!existing) {
+          await this.agentWorkflowsDatabaseService.create({
+            agent_id: updatedAgent.id,
+            workflow_id: workflow.id,
+            status: Status.Active,
+          });
+        }
         visitedWorkflows[workflow.id] = true;
       } catch (error) {
-        console.error('Failed to create agent-workflow association:', error);
+        console.error('Failed to upsert agent-workflow association:', error);
       }
     }
 
@@ -48,14 +55,21 @@ export class AgentService {
     const visitedResources: Record<string, boolean> = {};
     for (const resource of agent.resources) {
       try {
-        await this.agentResourcesDatabaseService.create({
+        // Avoid duplicates by checking for existing association first
+        const existing = await this.agentResourcesDatabaseService.getOneByFields({
           agent_id: updatedAgent.id,
           resource_id: resource.id,
-          status: Status.Active,
-        });
+        } as any);
+        if (!existing) {
+          await this.agentResourcesDatabaseService.create({
+            agent_id: updatedAgent.id,
+            resource_id: resource.id,
+            status: Status.Active,
+          });
+        }
         visitedResources[resource.id] = true;
       } catch (error) {
-        console.error('Failed to create agent-resource association:', error);
+        console.error('Failed to upsert agent-resource association:', error);
       }
     }
 

--- a/packages/core/src/services/database.service.ts
+++ b/packages/core/src/services/database.service.ts
@@ -140,6 +140,26 @@ export class PublicDatabaseService<T extends keyof Database['public']['Tables']>
     return data!;
   }
 
+  async upsert(
+    payload: Omit<Database['public']['Tables'][T]['Insert'], 'created_at'>,
+    conflictTarget?: string | string[]
+  ): Promise<Database['public']['Tables'][T]['Row']> {
+    const onConflict = conflictTarget
+      ? Array.isArray(conflictTarget)
+        ? conflictTarget.join(',')
+        : conflictTarget
+      : undefined;
+
+    const { data, error } = await this.getClient()
+      .from(this.table as string)
+      .upsert(payload as any, onConflict ? { onConflict } : undefined)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data!;
+  }
+
   async update(
     id: string,
     updates: Partial<Database['public']['Tables'][T]['Update']>


### PR DESCRIPTION
Avoid popping current resources


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate associations between agents and their workflows or resources.
  * Improved error messages to clarify when associations already exist.
* **New Features**
  * Added support for upsert operations to streamline data updates and avoid duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->